### PR TITLE
Fix for a prefix removal bug

### DIFF
--- a/resumable/widgets.py
+++ b/resumable/widgets.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import magic
+import re
 
 from django.forms.widgets import FileInput
 from django.core.files.storage import FileSystemStorage
@@ -33,7 +34,7 @@ class ResumableFileInput(FileInput):
             file = storage.open(filepath)
             size = storage.size(filepath)
             self.filepath = filepath
-            self.filename = filepath.replace('%s_' % unicode(size), '', 1)
+            self.filename = re.sub('^%s_' % unicode(size), '', filepath)
             return UploadedFile(
                 file=file,
                 name=self.filename,

--- a/resumable/widgets.py
+++ b/resumable/widgets.py
@@ -33,7 +33,7 @@ class ResumableFileInput(FileInput):
             file = storage.open(filepath)
             size = storage.size(filepath)
             self.filepath = filepath
-            self.filename = filepath.lstrip('%s_' % unicode(size))
+            self.filename = filepath.replace('%s_' % unicode(size), '', 1)
             return UploadedFile(
                 file=file,
                 name=self.filename,


### PR DESCRIPTION
I've had a case where lstrip matched more than just the size prefix and removed some number I had in the original filename.
Doing str.replace here might be better since it would just match and replace the prefix once with an empty string.