### PR TITLE
Add settings for prepending filesize to filename

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,3 +89,9 @@ Javascript
             <script type="text/javascript" src="{% static 'resumable/js/init.js' %}"></script>
         </body>
     </html>
+
+
+Settings
+--------
+
+``RESUMABLE_FILENAME_PREPEND_FILESIZE`` default ``True``: Otherwise it'll use the original filename.

--- a/resumable/files.py
+++ b/resumable/files.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 import fnmatch
 
+from django.conf import settings
+
+RESUMABLE_FILENAME_PREPEND_FILESIZE = getattr(settings, 'RESUMABLE_FILENAME_PREPEND_FILESIZE', True)
+
 
 class ResumableFile(object):
     def __init__(self, storage, kwargs):
@@ -42,10 +46,12 @@ class ResumableFile(object):
         filename = self.kwargs.get('resumableFilename')
         if '/' in filename:
             raise Exception('Invalid filename')
-        return "%s_%s" % (
-            self.kwargs.get('resumableTotalSize'),
-            filename
-        )
+        if RESUMABLE_FILENAME_PREPEND_FILESIZE:
+            return "%s_%s" % (
+                self.kwargs.get('resumableTotalSize'),
+                filename
+            )
+        return "%s" % filename
 
     @property
     def is_complete(self):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description='Django resumable uploads',
     long_description=open('README.rst').read(),
     install_requires=[
-        'Django>=1.10',
+        'Django>=1.9',
         'python-magic',
     ],
     classifiers=[


### PR DESCRIPTION
Added `RESUMABLE_FILENAME_PREPEND_FILESIZE` default to `True`, so it'll preserve original behavior or prepending filesize to filename.

That way it'll be possible to set it to `False` in order to save files with the original filename.